### PR TITLE
[MRG] More signature information, docstrings and information flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,12 @@ matrix:
       services: docker
       python: '3.7'
 
+    - os: linux
+      dist: xenial    
+      sudo: required
+      services: docker
+      python: '3.8-dev'
+
 # The Travis CI job lifecycle specifies the order of the commands below phases.
 # https://docs.travis-ci.com/user/job-lifecycle/#the-job-lifecycle
 

--- a/treedoc/main.py
+++ b/treedoc/main.py
@@ -144,20 +144,20 @@ def main():
     printing.add_argument(
         "--signature",
         action="store",
-        default=1,
+        default=2,
         dest="signature",
         type=int,
-        choices=[0, 1, 2],
+        choices=[0, 1, 2, 3, 4],
         help="how much signature information to show.",
     )
 
     printing.add_argument(
         "--docstring",
         action="store",
-        default=2,
+        default=1,
         dest="docstring",
         type=int,
-        choices=[0, 1, 2, 3, 4],
+        choices=[0, 1, 2],
         help="how much docstring information to show.",
     )
 

--- a/treedoc/main.py
+++ b/treedoc/main.py
@@ -39,7 +39,7 @@ def treedoc(
     if obj is None:
         raise ValueError("Could not resolve object")
 
-    printer = printer(signature=signature, docstring=docstring)
+    printer = printer(signature=signature, docstring=docstring, info=info)
     traverser = ObjectTraverser(
         level=level, private=private, magic=magic, stream=stream
     )

--- a/treedoc/printing.py
+++ b/treedoc/printing.py
@@ -124,50 +124,46 @@ class TreePrinter(Printer, PrinterABC):
         return format_signature(leaf_object, verbosity=self.signature)
 
     def format_iterable(self, iterable):
-
-        iterable = Peekable(iter(iterable))
+        """Formats rows and print stack yielded by iterable."""
 
         for print_stack, stack in self._format_row(iterable):
             joined_print_stack = " ".join(print_stack)
 
+            # Infor determines how much to show
             if self.info == 0:
-                obj_names = stack[
-                    -1
-                ].__name__  # ".".join([s.__name__ for s in stack[-1]])
+                obj_names = stack[-1].__name__
             else:
                 obj_names = ".".join([s.__name__ for s in stack])
+            # TODO: Differentiate between INFO = 1 AND INFO = 2
 
-            *_, last_obj = stack
+            last_obj = stack[-1]
             signature = self._format_argspec(last_obj)
             docstring = self._get_docstring(last_obj)
 
+            yield " ".join([joined_print_stack, obj_names]) + signature
+
+            # No need to show docstring, or no docstring to show, simply continue
             if self.docstring == 0 or docstring == "":
-                yield " ".join([joined_print_stack, obj_names]) + signature
                 continue
 
             # Want to print with docstring on the new line. Logic to switch up symbols
             last_in_stack = print_stack[-1]
             if last_in_stack == self.RIGHT:
-                symbol1 = self.RIGHT
-                symbol2 = self.DOWN
+                symbol = self.DOWN
             elif last_in_stack == self.LAST:
-                symbol1 = self.LAST
-                symbol2 = self.BLANK
+                symbol = self.BLANK
             else:
-                symbol1 = print_stack[-1]
-                symbol2 = ""
+                symbol = ""
 
-            print_stack[-1] = symbol1
-            yield " ".join([" ".join(print_stack), obj_names]) + signature
-            print_stack[-1] = symbol2
+            print_stack[-1] = symbol
             yield " ".join([" ".join(print_stack), '"{}"'.format(docstring)])
 
     def _format_row(self, iterator, depth=0, print_stack=None):
         """Format a row."""
 
         if not isinstance(iterator, Peekable):
-            raise TypeError("The iterator must be peekable.")
-        iterator = iter(iterator)
+            iterator = Peekable(iter(iterator))
+
         print_stack = print_stack or [""]
 
         # =============================================================================

--- a/treedoc/printing.py
+++ b/treedoc/printing.py
@@ -8,7 +8,7 @@ import abc
 import collections
 import inspect
 
-from treedoc.utils import Peekable, get_docstring, inspect_classify
+from treedoc.utils import Peekable, get_docstring, inspect_classify, format_signature
 
 
 class PrinterABC(abc.ABC):
@@ -41,8 +41,8 @@ class Printer:
         """
         Initialize a printer.
         """
-        assert signature in (0, 1, 2)
-        assert docstring in (0, 1, 2, 3, 4)
+        assert signature in (0, 1, 2, 3, 4)
+        assert docstring in (0, 1, 2)
         assert info in (0, 1, 2, 3, 4)
         self.signature = signature
         self.docstring = docstring
@@ -127,6 +127,8 @@ class TreePrinter(Printer, PrinterABC):
 
     def _format_argspec(self, leaf_object):
         """Get and format argspec from the leaf object in the tree path."""
+        
+        return format_signature(leaf_object, verbosity=self.signature)
 
         # Attempt to get a signature for the leaf object
         try:

--- a/treedoc/tests/test_cli.py
+++ b/treedoc/tests/test_cli.py
@@ -4,25 +4,60 @@
 Test the command line interface.
 """
 import subprocess
-
+import random
+import itertools
 import pytest
 
 
-@pytest.mark.parametrize(
-    "obj_string",
-    [
-        "list",
-        "collections",
-        "collections.Counter",
-        "math",
-        "collections.abc.Collection",
-    ],
-)
+object_strings = [
+    "list",
+    "collections",
+    "collections.Counter",
+    "math",
+    "collections.abc.Collection",
+]
+
+
+@pytest.mark.parametrize("obj_string", object_strings)
 def test_cli_smoketests(obj_string):
     """The smoketests assure that the commands run without errors. No output testing
     is performed apart from the non-existence of an error."""
 
     exit_code, output = subprocess.getstatusoutput(" ".join(["treedoc", obj_string]))
+
+    # Zero exit code means everything is OK
+    assert exit_code == 0
+
+
+def _generate_cli_args(n):
+    """Generate n args."""
+    random.seed(42)
+
+    yielded = set()
+
+    for _ in range(n):
+        info = "--info " + str(random.choice([0, 1, 2]))
+        docstring = "--docstring " + str(random.choice([0, 1, 2]))
+        signature = "--signature " + str(random.choice([0, 1, 2, 3, 4]))
+
+        to_yield = " ".join([info, docstring, signature])
+        if to_yield not in yielded:
+            yielded.add(to_yield)
+            yield to_yield
+
+
+@pytest.mark.parametrize(
+    "arg_string",
+    [
+        " ".join([i, j])
+        for i, j in itertools.product(object_strings, _generate_cli_args(5))
+    ],
+)
+def test_cli_smoketests_w_args(arg_string):
+    """The smoketests assure that the commands run without errors. No output testing
+    is performed apart from the non-existence of an error."""
+
+    exit_code, output = subprocess.getstatusoutput(" ".join(["treedoc", arg_string]))
 
     # Zero exit code means everything is OK
     assert exit_code == 0

--- a/treedoc/utils.py
+++ b/treedoc/utils.py
@@ -270,8 +270,8 @@ def signature_from_docstring(obj):
     `dict.pop`. This method will retrieve the docstring, and return None if it cannot.
     
     >>> import math
-    >>> signature_from_docstring(math.log)
-    'x, [base=math.e]'
+    >>> signature_from_docstring(math.log) in ('x[, base]', 'x, [base=math.e]')
+    True
     >>> signature_from_docstring(dict.pop)
     'k[,d]'
     """
@@ -309,7 +309,7 @@ def format_signature(obj, verbosity=2):
     Examples
     --------
     >>> import collections
-    >>> # Work on functions with well-defined signature
+    >>> # Works on functions with well-defined signature
     >>> format_signature(collections.defaultdict.fromkeys, verbosity=2)
     '(iterable, value)'
     >>> # Built-ins with signature information in the docs

--- a/treedoc/utils.py
+++ b/treedoc/utils.py
@@ -272,8 +272,8 @@ def signature_from_docstring(obj):
     >>> import math
     >>> signature_from_docstring(math.log) in ('x[, base]', 'x, [base=math.e]')
     True
-    >>> signature_from_docstring(dict.pop)
-    'k[,d]'
+    >>> signature_from_docstring(dict.pop) in ('k[,d]', None)
+    True
     """
 
     # If not docstring is available, return


### PR DESCRIPTION
### Bugs

- Fixed a bug where `--docstring` was allowed values 0...4, but `--signature` only 0...2. It's supposed to be the other way around.
- The `Peekable` class was defined twice.

### Signature information is now retrieved from the first line of the docstring

```python
>>> import collections
>>> # Works on functions with well-defined signature
>>> format_signature(collections.defaultdict.fromkeys, verbosity=2)
'(iterable, value)'
>>> # Built-ins with signature information in the docs
>>> format_signature(collections.defaultdict.update, verbosity=2)
'([E, ]**F)'
>>> # Built-ins with signature no signature information at all
>>> format_signature(collections.deque.append, verbosity=2)
'(...)'
```

### Added docstring information

```bash
(treedoc) > $ treedoc collections | head
 collections
 "This module implements specialized container datatypes providing alternatives to..."
 ├── collections.ChainMap(*maps)
 │   "A ChainMap groups multiple dicts (or other mappings) together to create a single,..."
 │   ├── collections.ChainMap.copy(self)
 │   │   "New ChainMap or subclass with a new copy of maps[0] and refs to maps[1:]"
 │   ├── collections.ChainMap.clear(self)
 │   │   "Clear maps[0], leaving maps[1:] intact."
 │   ├── collections.ChainMap.copy(self)
 │   │   "New ChainMap or subclass with a new copy of maps[0] and refs to maps[1:]"
```
### Implemented `--info 0`

Turns of the dot-notation name, uses only object name.

```bash
(treedoc) > $ treedoc collections --info 0 | head
 collections
 "This module implements specialized container datatypes providing alternatives to..."
 ├── ChainMap(*maps)
 │   "A ChainMap groups multiple dicts (or other mappings) together to create a single,..."
 │   ├── copy(self)
 │   │   "New ChainMap or subclass with a new copy of maps[0] and refs to maps[1:]"
 │   ├── clear(self)
 │   │   "Clear maps[0], leaving maps[1:] intact."
 │   ├── copy(self)
 │   │   "New ChainMap or subclass with a new copy of maps[0] and refs to maps[1:]"

```