### PR TITLE
[MRG] Restricting signature width output

### DIFF
--- a/treedoc/main.py
+++ b/treedoc/main.py
@@ -10,6 +10,7 @@ import sys
 
 from treedoc.printing import DensePrinter, TreePrinter, resolve_input
 from treedoc.traversal import ObjectTraverser
+from treedoc.utils import get_terminal_size
 
 
 def treedoc(
@@ -40,6 +41,10 @@ def treedoc(
     >>> treedoc(list)
     >>> treedoc("collections.Counter")
     """
+
+    # A zero means that no width was explicitly set, if so we set it to terminal width
+    if width == 0:
+        width, _ = get_terminal_size()
 
     # Resolve the object
     objects = resolve_input(obj)
@@ -199,7 +204,7 @@ def setup_argumentparser(printers):
         "-W",
         "--width",
         action="store",
-        default=88,
+        default=0,
         dest="width",
         type=int,
         # choices=range(50, 500),

--- a/treedoc/printing.py
+++ b/treedoc/printing.py
@@ -508,8 +508,10 @@ def format_signature(obj, *, verbosity=2, width=88) -> str:
 
     # It's too wide, shorten it and return
     inner_sig = str(signature_string).strip("()")
-    inner_sig = textwrap.shorten(inner_sig, width=width - 2)
-    return "(" + inner_sig + ")"
+    inner_sig = textwrap.shorten(inner_sig, width=width - 2, placeholder=" ...")
+    result = "(" + inner_sig + ")"
+    assert len(result) <= width
+    return result
 
 
 def _format_signature(obj, *, verbosity=2) -> str:

--- a/treedoc/printing.py
+++ b/treedoc/printing.py
@@ -468,7 +468,7 @@ def signature_from_docstring(obj):
     return None
 
 
-def format_signature(obj, verbosity=2):
+def format_signature(obj, *, verbosity=2, width=88) -> str:
     """ 
     Format a function signature for printing.
     

--- a/treedoc/tests/test_printing.py
+++ b/treedoc/tests/test_printing.py
@@ -365,7 +365,7 @@ class TestSignature:
 
         assert (
             "".join(
-                char for char in format_signature(myfunc1, verbosity) if char != " "
+                char for char in format_signature(myfunc1, verbosity=verbosity) if char != " "
             )
             == expected
         )
@@ -382,7 +382,7 @@ class TestSignature:
         def myfunc2():
             return None
 
-        assert format_signature(myfunc2, verbosity) == expected
+        assert format_signature(myfunc2, verbosity=verbosity) == expected
 
     @staticmethod
     @pytest.mark.parametrize(
@@ -401,7 +401,7 @@ class TestSignature:
         """
         from collections import Counter
 
-        assert format_signature(Counter.most_common, verbosity) == expected
+        assert format_signature(Counter.most_common, verbosity=verbosity) == expected
 
     @staticmethod
     @pytest.mark.parametrize("verbosity, expected", parameters)
@@ -414,7 +414,7 @@ class TestSignature:
         assert (
             "".join(
                 char
-                for char in format_signature(myclass.method_bound_to_myclass, verbosity)
+                for char in format_signature(myclass.method_bound_to_myclass, verbosity=verbosity)
                 if char != " "
             )
             == expected
@@ -441,7 +441,7 @@ class TestSignature:
             "".join(
                 char
                 for char in format_signature(
-                    myclass.static_method_bound_to_myclass, verbosity
+                    myclass.static_method_bound_to_myclass, verbosity=verbosity
                 )
                 if char != " "
             )
@@ -450,22 +450,11 @@ class TestSignature:
 
     @staticmethod
     @pytest.mark.parametrize("verbosity, expected", parameters)
-    def test_class_method(verbosity, expected):
+    def test_width_restriction(verbosity, expected):
         """
         Test that formatting signature works on a class method.
         """
-        myclass = treedoctestpackage.MyClass()
-
-        assert (
-            "".join(
-                char
-                for char in format_signature(
-                    myclass.classmethod_bound_to_myclass, verbosity
-                )
-                if char != " "
-            )
-            == expected
-        )
+        assert True
 
 
 if __name__ == "__main__":

--- a/treedoc/tests/test_printing.py
+++ b/treedoc/tests/test_printing.py
@@ -7,6 +7,7 @@ Tests for classes and functions located in `printing.py`.
 import builtins
 import collections.abc
 import datetime
+import itertools
 import math
 import operator
 from collections.abc import Callable
@@ -365,7 +366,9 @@ class TestSignature:
 
         assert (
             "".join(
-                char for char in format_signature(myfunc1, verbosity=verbosity) if char != " "
+                char
+                for char in format_signature(myfunc1, verbosity=verbosity)
+                if char != " "
             )
             == expected
         )
@@ -414,7 +417,9 @@ class TestSignature:
         assert (
             "".join(
                 char
-                for char in format_signature(myclass.method_bound_to_myclass, verbosity=verbosity)
+                for char in format_signature(
+                    myclass.method_bound_to_myclass, verbosity=verbosity
+                )
                 if char != " "
             )
             == expected
@@ -449,12 +454,17 @@ class TestSignature:
         )
 
     @staticmethod
-    @pytest.mark.parametrize("verbosity, expected", parameters)
-    def test_width_restriction(verbosity, expected):
-        """
-        Test that formatting signature works on a class method.
-        """
-        assert True
+    def test_width_restriction():
+        """Test that the width is always respected."""
+
+        func = treedoctestpackage.module.func_many_long_args
+
+        generator = itertools.product(list(range(15, 100)), [0, 1, 2, 3, 4])
+        for width, verbosity in generator:
+            formatted_signature = format_signature(
+                func, width=width, verbosity=verbosity
+            )
+            assert len(formatted_signature) <= width
 
 
 if __name__ == "__main__":

--- a/treedoc/tests/treedoctestpackage/module.py
+++ b/treedoc/tests/treedoctestpackage/module.py
@@ -37,7 +37,15 @@ def func_many_args(a, b=2, c=4, d=(1, 2, 3)):
     """Function with many arguments."""
     return b + c
 
-def func_many_long_args(arg:str='default', second_arg:int=1232456789, third_and_final_argument:str='long_default'):
+
+def func_many_long_args(
+    arg=2,
+    num: int = 123,
+    name: str = "john",
+    pi: float = 3.14,
+    place: str = "london",
+    e: float = 2.718281828459045,
+):
     """Function with many arguments."""
     return None
 

--- a/treedoc/tests/treedoctestpackage/module.py
+++ b/treedoc/tests/treedoctestpackage/module.py
@@ -37,6 +37,10 @@ def func_many_args(a, b=2, c=4, d=(1, 2, 3)):
     """Function with many arguments."""
     return b + c
 
+def func_many_long_args(arg:str='default', second_arg:int=1232456789, third_and_final_argument:str='long_default'):
+    """Function with many arguments."""
+    return None
+
 
 def generator(a):
     for i in range(a):

--- a/treedoc/traversal.py
+++ b/treedoc/traversal.py
@@ -301,11 +301,23 @@ class ObjectTraverser(PrintMixin):
         def unique_first(gen1, gen2):
             """Chain generators, but only one unique name."""
             # Using a list would be faster, but modules are not hashable, so O(n) lookup
-            seen = []
-            for a, b in itertools.chain(generator1, generator2):
-                if b not in seen:
-                    seen.append(b)
-                    yield a, b
+            seen_objects = []
+            seen_names = set()
+            for name, obj in itertools.chain(generator1, generator2):
+                try:
+                    if obj not in seen_objects:
+                        seen_objects.append(obj)
+                        seen_names.add(name)
+                        yield name, obj
+
+                # The comparison operation has been overwritten. Fall back to naming
+                # This happen for instance with pandas NaT (Not a Time)
+                except TypeError:
+
+                    if name not in seen_names:
+                        seen_objects.append(obj)
+                        seen_names.add(name)
+                        yield name, obj
 
         generator = unique_first(generator1, generator2)
 

--- a/treedoc/utils.py
+++ b/treedoc/utils.py
@@ -5,6 +5,7 @@ General utilities for treedoc.
 """
 
 import collections
+import os
 
 
 class PrintMixin:
@@ -76,3 +77,19 @@ class Peekable:
             return self._cache.popleft()
 
         return next(self._it)
+
+
+def get_terminal_size(fallback=(80, 24)):
+    """Get the terminal size.
+    
+    See http://granitosaurus.rocks/getting-terminal-size.html
+    """
+    for i in range(0, 3):
+        try:
+            columns, rows = os.get_terminal_size(i)
+        except OSError:
+            continue
+        break
+    else:  # set default if the loop completes which means all failed
+        columns, rows = fallback
+    return columns, rows


### PR DESCRIPTION
This PR will reduce the width of signatures, controlled by the `-W` argument.

For instance, running `treedoc pandas.DataFrame` yields:
```
DataFrame.to_latex(self, buf, columns, col_space, header, index, na_rep, formatters, float_format, sparsify, index_names, bold_rows, column_format, longtable, escape, encoding, decimal, multicolumn, multicolumn_format, multirow)
```

This looks a bit awkward. I prefer
```
DataFrame.to_latex(self, buf, columns, col_space, header, index, na_rep, formatters, ...)
```
and letting the user increase the number of args with `-W` if needed.