### PR TITLE
[MRG] added CLI argument to print version

### DIFF
--- a/treedoc/main.py
+++ b/treedoc/main.py
@@ -81,6 +81,15 @@ def setup_argumentparser(printers):
         help="package/class/method/... , e.g. collections.Counter",
     )
 
+    parser.add_argument(
+        "-v",
+        "--version",
+        default=False,
+        dest="version",
+        action="store_true",
+        help="print the version and exit.",
+    )
+
     # =============================================================================
     #     OPTIONS RELATED TO OBJECT TRAVERSAL AND RECURSION
     # =============================================================================
@@ -215,6 +224,14 @@ def CLI_entrypoint():
     parser = setup_argumentparser(printers)
 
     args = parser.parse_args()
+
+    # The user wants to print the version. Print it and exit.
+    if args.version:
+        from treedoc import __version__
+
+        print("treedoc version {}".format(__version__))
+        return
+
     args_to_func = {k: w for (k, w) in args._get_kwargs()}
     args_to_func["printer"] = printers[args_to_func["printer"]]
 

--- a/treedoc/main.py
+++ b/treedoc/main.py
@@ -231,6 +231,8 @@ def CLI_entrypoint():
 
         print("treedoc version {}".format(__version__))
         return
+    else:
+        delattr(args, "version")
 
     args_to_func = {k: w for (k, w) in args._get_kwargs()}
     args_to_func["printer"] = printers[args_to_func["printer"]]

--- a/treedoc/traversal.py
+++ b/treedoc/traversal.py
@@ -88,8 +88,6 @@ class ObjectTraverser(PrintMixin):
             # Not defined in the sub-tree, skip it
             if not is_subpackage(inspect.getmodule(child_obj), obj):
 
-                print(inspect.getmodule(child_obj), obj)
-
                 self._p(f"OC: Failed on condition 1.2")
                 return False
 


### PR DESCRIPTION
`treedoc --version` or `treedoc -v` will now print the version. Could've put it in `treedoc --help`, but other famous CLI tools such as `ls`, `git`, `python`, `tree` all have the `--version` flag, so I want it too :+1: 

In python, one would do
```
>>> import treedoc
>>> treedoc.__version__
```
and this convention is followed by famous Python libraries.