### PR TITLE
[MRG] files now work as arguments too

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
-from os import path
 import re
+from os import path
+
 from setuptools import find_packages, setup
 
 # Get the long description from README.md

--- a/treedoc/printing.py
+++ b/treedoc/printing.py
@@ -694,17 +694,18 @@ def resolve_str_to_obj(object_string: str) -> object:
     base, package = os.path.split(os.path.realpath(possible_pkg))
 
     # Append the base to the system path and try to import the module
-    # This allows `__init__.py` in "package" to have relative imports such as
+    # This allows `__init__.py` in "package" to have imports such as
     # from .functions import func
-    # and we'll be able to get them
+    # from functions import func
+    # and we'll be able to get them. There are probably limits to this hack.
     sys.path.append(base)
-    # TODO: Would it be possible to expand logic so that `from functions import func`
-    # also works?
+    sys.path.append(package)
 
     try:
         return importlib.import_module(package)
     except:
         sys.path.pop()  # Clean up
+        sys.path.pop()
         raise
 
 

--- a/treedoc/printing.py
+++ b/treedoc/printing.py
@@ -694,10 +694,13 @@ def resolve_str_to_obj(object_string: str) -> object:
     base, package = os.path.split(os.path.realpath(possible_pkg))
 
     # Append the base to the system path and try to import the module
-    # This allows `__init__.py` in "package" to have imports such as
-    # from functions import func
+    # This allows `__init__.py` in "package" to have relative imports such as
+    # from .functions import func
     # and we'll be able to get them
     sys.path.append(base)
+    # TODO: Would it be possible to expand logic so that `from functions import func`
+    # also works?
+
     try:
         return importlib.import_module(package)
     except:

--- a/treedoc/tests/test_printing.py
+++ b/treedoc/tests/test_printing.py
@@ -314,6 +314,14 @@ class TestObjectResolution:
             resolve_str_to_obj("gibberish")
 
     @staticmethod
+    def test_resolve_str_to_obj_from_file():
+        """Test that object resolution works on files."""
+
+        filename = operator.__file__
+
+        assert resolve_str_to_obj(filename) == resolve_str_to_obj("operator")
+
+    @staticmethod
     @pytest.mark.parametrize(
         "input_arg, expected",
         [


### PR DESCRIPTION
Closes #17 !

- `treedoc file.py` should work on a general file if it's in the current directory.
- `treedoc /home/tommy/file.py` should also work.
- `treedoc uninstalled_package --modules` works if the imports in `uninstalled_package/__init__.py` are relative or absolute, e.g., `from .mathfuns import func` or `from .mathfuns import func`. Without the `--modules` flag only the relative imports work. Not sure why.

Happy with this for now. Added functionality, no breaking changes. Let's merge if it looks OK to you.

We can look into that very special case in the future... Maybe.