### PR TITLE
Require minimum Python version - Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,4 +37,5 @@ setup(
         "Programming Language :: Python :: 3.8",
     ],
     keywords=["documentation, utility"],
+    python_requires='>=3.6'
 )


### PR DESCRIPTION
Add python version requirement to versions (3.6+) that support f-strings. Trying e.g. 'treedoc list' on python 3.5 renders the following error:

File "/Users/davidf/anaconda3/envs/framo/lib/python3.5/site-packages/treedoc/traversal.py", line 69
    pprint(f"yield_data({obj}, stack={stack})")